### PR TITLE
v0.2, py3 only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,3 @@ __pycache__/
 
 #env
 env/
-
-# setuptools
-/asks.egg-info/
-/build/
-/dist/
-
-# docs
-/docs/build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
 MANIFEST
+__pycache__/
+*.pyc
+
+# pytest
+/.cache/
+/.pytest_cache/
+
+#env
+env/
+
+# setuptools
+/asks.egg-info/
+/build/
+/dist/
+
+# docs
+/docs/build/

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,14 @@ MANIFEST
 __pycache__/
 *.pyc
 
+# tests
+test.run
+html/
+
 # pytest
 /.cache/
 /.pytest_cache/
 
 #env
 env/
+

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2010, Marcel Hellkamp.
+Inspired by the Werkzeug library: http://werkzeug.pocoo.org/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Compared to cgi.FieldStorage()
 Limitations
 -----------
 
-* Nested "multipart/mixed" parts are not supported; 
+* Nested "multipart/mixed" parts are not supported;
   they are mentioned in RFC 2388, section 4.2 and deprecated (for clients) since RFC 7578, section 4.3.
 
 * The "encoded-word" method (described in RFC 2047) is not supported.
@@ -41,28 +41,3 @@ Todo
 ----
 
 * Support for base64 and quoted-printable transfer encoding.
-
-Licence (MIT)
--------------
-
-    Copyright (c) 2010, Marcel Hellkamp.
-    Inspired by the Werkzeug library: http://werkzeug.pocoo.org/
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,12 @@ Limitations
 
 * The size of headers are not counted against the in-memory limit.
 
+Testing
+-------
+
+Tests require `coverage`.
+`pip install coverage`
+
 Todo
 ----
 

--- a/multipart.py
+++ b/multipart.py
@@ -1,28 +1,29 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Parser for multipart/form-data
 ==============================
 
 This module provides a parser for the multipart/form-data format. It can read
 from a file, a socket or a WSGI environment. The parser can be used to replace
 cgi.FieldStorage (without the bugs) and works with Python 2.5+ and 3.x (2to3).
-'''
+"""
 
 
-__author__ = 'Marcel Hellkamp'
-__version__ = '0.1'
-__license__ = 'MIT'
+__author__ = "Marcel Hellkamp"
+__version__ = "0.1"
+__license__ = "MIT"
 
 from tempfile import TemporaryFile
 from wsgiref.headers import Headers
 import re, sys
+
 try:
     from urlparse import parse_qs
-except ImportError: # pragma: no cover (fallback for Python 2.5)
+except ImportError:  # pragma: no cover (fallback for Python 2.5)
     from cgi import parse_qs
 try:
     from io import BytesIO
-except ImportError: # pragma: no cover (fallback for Python 2.5)
+except ImportError:  # pragma: no cover (fallback for Python 2.5)
     from StringIO import StringIO as BytesIO
 
 ##############################################################################
@@ -32,27 +33,47 @@ except ImportError: # pragma: no cover (fallback for Python 2.5)
 
 try:
     from collections import MutableMapping as DictMixin
-except ImportError: # pragma: no cover (fallback for Python 2.5)
+except ImportError:  # pragma: no cover (fallback for Python 2.5)
     from UserDict import DictMixin
+
 
 class MultiDict(DictMixin):
     """ A dict that remembers old values for each key """
+
     def __init__(self, *a, **k):
         self.dict = dict()
         for k, v in dict(*a, **k).iteritems():
             self[k] = v
 
-    def __len__(self): return len(self.dict)
-    def __iter__(self): return iter(self.dict)
-    def __contains__(self, key): return key in self.dict
-    def __delitem__(self, key): del self.dict[key]
-    def keys(self): return self.dict.keys()
-    def __getitem__(self, key): return self.get(key, KeyError, -1)
-    def __setitem__(self, key, value): self.append(key, value)
+    def __len__(self):
+        return len(self.dict)
 
-    def append(self, key, value): self.dict.setdefault(key, []).append(value)
-    def replace(self, key, value): self.dict[key] = [value]
-    def getall(self, key): return self.dict.get(key) or []
+    def __iter__(self):
+        return iter(self.dict)
+
+    def __contains__(self, key):
+        return key in self.dict
+
+    def __delitem__(self, key):
+        del self.dict[key]
+
+    def keys(self):
+        return self.dict.keys()
+
+    def __getitem__(self, key):
+        return self.get(key, KeyError, -1)
+
+    def __setitem__(self, key, value):
+        self.append(key, value)
+
+    def append(self, key, value):
+        self.dict.setdefault(key, []).append(value)
+
+    def replace(self, key, value):
+        self.dict[key] = [value]
+
+    def getall(self, key):
+        return self.dict.get(key) or []
 
     def get(self, key, default=None, index=-1):
         if key not in self.dict and default != KeyError:
@@ -64,74 +85,90 @@ class MultiDict(DictMixin):
             for value in values:
                 yield key, value
 
-def tob(data, enc='utf8'): # Convert strings to bytes (py2 and py3)
+
+def tob(data, enc="utf8"):  # Convert strings to bytes (py2 and py3)
     return data.encode(enc) if isinstance(data, unicode) else data
 
-def copy_file(stream, target, maxread=-1, buffer_size=2*16):
-    ''' Read from :stream and write to :target until :maxread or EOF. '''
+
+def copy_file(stream, target, maxread=-1, buffer_size=2 * 16):
+    """ Read from :stream and write to :target until :maxread or EOF. """
     size, read = 0, stream.read
     while 1:
-        to_read = buffer_size if maxread < 0 else min(buffer_size, maxread-size)
+        to_read = buffer_size if maxread < 0 else min(buffer_size, maxread - size)
         part = read(to_read)
-        if not part: return size
+        if not part:
+            return size
         target.write(part)
         size += len(part)
+
 
 ##############################################################################
 ################################ Header Parser ################################
 ##############################################################################
 
 _special = re.escape('()<>@,;:\\"/[]?={} \t')
-_re_special = re.compile('[%s]' % _special)
-_qstr = '"(?:\\\\.|[^"])*"' # Quoted string
-_value = '(?:[^%s]+|%s)' % (_special, _qstr) # Save or quoted string
-_option = '(?:;|^)\s*([^%s]+)\s*=\s*(%s)' % (_special, _value)
-_re_option = re.compile(_option) # key=value part of an Content-Type like header
+_re_special = re.compile("[%s]" % _special)
+_qstr = '"(?:\\\\.|[^"])*"'  # Quoted string
+_value = "(?:[^%s]+|%s)" % (_special, _qstr)  # Save or quoted string
+_option = "(?:;|^)\s*([^%s]+)\s*=\s*(%s)" % (_special, _value)
+_re_option = re.compile(_option)  # key=value part of an Content-Type like header
+
 
 def header_quote(val):
     if not _re_special.search(val):
         return val
-    return '"' + val.replace('\\','\\\\').replace('"','\\"') + '"'
+    return '"' + val.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
 
 def header_unquote(val, filename=False):
     if val[0] == val[-1] == '"':
         val = val[1:-1]
-        if val[1:3] == ':\\' or val[:2] == '\\\\':
-            val = val.split('\\')[-1] # fix ie6 bug: full path --> filename
-        return val.replace('\\\\','\\').replace('\\"','"')
+        if val[1:3] == ":\\" or val[:2] == "\\\\":
+            val = val.split("\\")[-1]  # fix ie6 bug: full path --> filename
+        return val.replace("\\\\", "\\").replace('\\"', '"')
     return val
 
+
 def parse_options_header(header, options=None):
-    if ';' not in header:
+    if ";" not in header:
         return header.lower().strip(), {}
-    ctype, tail = header.split(';', 1)
+    ctype, tail = header.split(";", 1)
     options = options or {}
     for match in _re_option.finditer(tail):
         key = match.group(1).lower()
-        value = header_unquote(match.group(2), key=='filename')
+        value = header_unquote(match.group(2), key == "filename")
         options[key] = value
     return ctype, options
+
 
 ##############################################################################
 ################################## Multipart ##################################
 ##############################################################################
 
 
-class MultipartError(ValueError): pass
+class MultipartError(ValueError):
+    pass
 
 
 class MultipartParser(object):
-
-    def __init__(self, stream, boundary, content_length=-1,
-                 disk_limit=2**30, mem_limit=2**20, memfile_limit=2**18,
-                 buffer_size=2**16, charset='latin1'):
-        ''' Parse a multipart/form-data byte stream. This object is an iterator
+    def __init__(
+        self,
+        stream,
+        boundary,
+        content_length=-1,
+        disk_limit=2 ** 30,
+        mem_limit=2 ** 20,
+        memfile_limit=2 ** 18,
+        buffer_size=2 ** 16,
+        charset="latin1",
+    ):
+        """ Parse a multipart/form-data byte stream. This object is an iterator
             over the parts of the message.
 
             :param stream: A file-like stream. Must implement ``.read(size)``.
             :param boundary: The multipart boundary as a byte string.
             :param content_length: The maximum number of bytes to read.
-        '''
+        """
         self.stream, self.boundary = stream, boundary
         self.content_length = content_length
         self.disk_limit = disk_limit
@@ -139,13 +176,13 @@ class MultipartParser(object):
         self.mem_limit = min(mem_limit, self.disk_limit)
         self.buffer_size = min(buffer_size, self.mem_limit)
         self.charset = charset
-        if self.buffer_size - 6 < len(boundary): # "--boundary--\r\n"
-            raise MultipartError('Boundary does not fit into buffer_size.')
+        if self.buffer_size - 6 < len(boundary):  # "--boundary--\r\n"
+            raise MultipartError("Boundary does not fit into buffer_size.")
         self._done = []
         self._part_iter = None
 
     def __iter__(self):
-        ''' Iterate over the parts of the multipart message. '''
+        """ Iterate over the parts of the multipart message. """
         if not self._part_iter:
             self._part_iter = self._iterparse()
         for part in self._done:
@@ -155,74 +192,79 @@ class MultipartParser(object):
             yield part
 
     def parts(self):
-        ''' Returns a list with all parts of the multipart message. '''
+        """ Returns a list with all parts of the multipart message. """
         return list(iter(self))
 
     def get(self, name, default=None):
-        ''' Return the first part with that name or a default value (None). '''
+        """ Return the first part with that name or a default value (None). """
         for part in self:
             if name == part.name:
                 return part
         return default
 
     def get_all(self, name):
-        ''' Return a list of parts with that name. '''
+        """ Return a list of parts with that name. """
         return [p for p in self if p.name == name]
 
     def _lineiter(self):
-        ''' Iterate over a binary file-like object line by line. Each line is
+        """ Iterate over a binary file-like object line by line. Each line is
             returned as a (line, line_ending) tuple. If the line does not fit
             into self.buffer_size, line_ending is empty and the rest of the line
             is returned with the next iteration.
-        '''
+        """
         read = self.stream.read
         maxread, maxbuf = self.content_length, self.buffer_size
-        _bcrnl = tob('\r\n')
+        _bcrnl = tob("\r\n")
         _bcr = _bcrnl[:1]
         _bnl = _bcrnl[1:]
-        _bempty = _bcrnl[:0] # b'rn'[:0] -> b''
-        buffer = _bempty # buffer for the last (partial) line
+        _bempty = _bcrnl[:0]  # b'rn'[:0] -> b''
+        buffer = _bempty  # buffer for the last (partial) line
         while 1:
             data = read(maxbuf if maxread < 0 else min(maxbuf, maxread))
             maxread -= len(data)
-            lines = (buffer+data).splitlines(True)
+            lines = (buffer + data).splitlines(True)
             len_first_line = len(lines[0])
             # be sure that the first line does not become too big
             if len_first_line > self.buffer_size:
                 # at the same time don't split a '\r\n' accidentally
-                if (len_first_line == self.buffer_size+1 and
-                    lines[0].endswith(_bcrnl)):
+                if len_first_line == self.buffer_size + 1 and lines[0].endswith(_bcrnl):
                     splitpos = self.buffer_size - 1
                 else:
                     splitpos = self.buffer_size
-                lines[:1] = [lines[0][:splitpos],
-                             lines[0][splitpos:]]
+                lines[:1] = [lines[0][:splitpos], lines[0][splitpos:]]
             if data:
                 buffer = lines[-1]
                 lines = lines[:-1]
             for line in lines:
-                if line.endswith(_bcrnl): yield line[:-2], _bcrnl
-                elif line.endswith(_bnl): yield line[:-1], _bnl
-                elif line.endswith(_bcr): yield line[:-1], _bcr
-                else:                     yield line, _bempty
+                if line.endswith(_bcrnl):
+                    yield line[:-2], _bcrnl
+                elif line.endswith(_bnl):
+                    yield line[:-1], _bnl
+                elif line.endswith(_bcr):
+                    yield line[:-1], _bcr
+                else:
+                    yield line, _bempty
             if not data:
                 break
 
     def _iterparse(self):
-        lines, line = self._lineiter(), ''
-        separator = tob('--') + tob(self.boundary)
-        terminator = tob('--') + tob(self.boundary) + tob('--')
+        lines, line = self._lineiter(), ""
+        separator = tob("--") + tob(self.boundary)
+        terminator = tob("--") + tob(self.boundary) + tob("--")
         # Consume first boundary. Ignore leading blank lines
         for line, nl in lines:
-            if line: break
+            if line:
+                break
         if line != separator:
             raise MultipartError("Stream does not start with boundary")
         # For each part in stream...
-        mem_used, disk_used = 0, 0 # Track used resources to prevent DoS
-        is_tail = False # True if the last line was incomplete (cutted)
-        opts = {'buffer_size': self.buffer_size,
-                'memfile_limit': self.memfile_limit,
-                'charset': self.charset}
+        mem_used, disk_used = 0, 0  # Track used resources to prevent DoS
+        is_tail = False  # True if the last line was incomplete (cutted)
+        opts = {
+            "buffer_size": self.buffer_size,
+            "memfile_limit": self.memfile_limit,
+            "charset": self.charset,
+        }
         part = MultipartPart(**opts)
         for line, nl in lines:
             if line == terminator and not is_tail:
@@ -230,13 +272,15 @@ class MultipartParser(object):
                 yield part
                 break
             elif line == separator and not is_tail:
-                if part.is_buffered(): mem_used  += part.size
-                else:                  disk_used += part.size
+                if part.is_buffered():
+                    mem_used += part.size
+                else:
+                    disk_used += part.size
                 part.file.seek(0)
                 yield part
                 part = MultipartPart(**opts)
             else:
-                is_tail = not nl # The next line continues this one
+                is_tail = not nl  # The next line continues this one
                 part.feed(line, nl)
                 if part.is_buffered():
                     if part.size + mem_used > self.mem_limit:
@@ -248,78 +292,79 @@ class MultipartParser(object):
 
 
 class MultipartPart(object):
-
-    def __init__(self, buffer_size=2**16, memfile_limit=2**18, charset='latin1'):
+    def __init__(self, buffer_size=2 ** 16, memfile_limit=2 ** 18, charset="latin1"):
         self.headerlist = []
         self.headers = None
         self.file = False
         self.size = 0
-        self._buf = tob('')
+        self._buf = tob("")
         self.disposition, self.name, self.filename = None, None, None
         self.content_type, self.charset = None, charset
         self.memfile_limit = memfile_limit
         self.buffer_size = buffer_size
 
-    def feed(self, line, nl=''):
+    def feed(self, line, nl=""):
         if self.file:
             return self.write_body(line, nl)
         return self.write_header(line, nl)
 
     def write_header(self, line, nl):
-        line = line.decode(self.charset or 'latin1')
-        if not nl: raise MultipartError('Unexpected end of line in header.')
-        if not line.strip(): # blank line -> end of header segment
+        line = line.decode(self.charset or "latin1")
+        if not nl:
+            raise MultipartError("Unexpected end of line in header.")
+        if not line.strip():  # blank line -> end of header segment
             self.finish_header()
-        elif line[0] in ' \t' and self.headerlist:
+        elif line[0] in " \t" and self.headerlist:
             name, value = self.headerlist.pop()
-            self.headerlist.append((name, value+line.strip()))
+            self.headerlist.append((name, value + line.strip()))
         else:
-            if ':' not in line:
+            if ":" not in line:
                 raise MultipartError("Syntax error in header: No colon.")
-            name, value = line.split(':', 1)
+            name, value = line.split(":", 1)
             self.headerlist.append((name.strip(), value.strip()))
 
     def write_body(self, line, nl):
-        if not line and not nl: return # This does not even flush the buffer
+        if not line and not nl:
+            return  # This does not even flush the buffer
         self.size += len(line) + len(self._buf)
         self.file.write(self._buf + line)
         self._buf = nl
         if self.content_length > 0 and self.size > self.content_length:
-            raise MultipartError('Size of body exceeds Content-Length header.')
+            raise MultipartError("Size of body exceeds Content-Length header.")
         if self.size > self.memfile_limit and isinstance(self.file, BytesIO):
             # TODO: What about non-file uploads that exceed the memfile_limit?
-            self.file, old = TemporaryFile(mode='w+b'), self.file
+            self.file, old = TemporaryFile(mode="w+b"), self.file
             old.seek(0)
             copy_file(old, self.file, self.size, self.buffer_size)
 
     def finish_header(self):
         self.file = BytesIO()
         self.headers = Headers(self.headerlist)
-        cdis = self.headers.get('Content-Disposition','')
-        ctype = self.headers.get('Content-Type','')
-        clen = self.headers.get('Content-Length','-1')
+        cdis = self.headers.get("Content-Disposition", "")
+        ctype = self.headers.get("Content-Type", "")
+        clen = self.headers.get("Content-Length", "-1")
         if not cdis:
-            raise MultipartError('Content-Disposition header is missing.')
+            raise MultipartError("Content-Disposition header is missing.")
         self.disposition, self.options = parse_options_header(cdis)
-        self.name = self.options.get('name')
-        self.filename = self.options.get('filename')
+        self.name = self.options.get("name")
+        self.filename = self.options.get("filename")
         self.content_type, options = parse_options_header(ctype)
-        self.charset = options.get('charset') or self.charset
-        self.content_length = int(self.headers.get('Content-Length','-1'))
+        self.charset = options.get("charset") or self.charset
+        self.content_length = int(self.headers.get("Content-Length", "-1"))
 
     def is_buffered(self):
-        ''' Return true if the data is fully buffered in memory.'''
+        """ Return true if the data is fully buffered in memory."""
         return isinstance(self.file, BytesIO)
 
     @property
     def value(self):
-        ''' Data decoded with the specified charset '''
+        """ Data decoded with the specified charset """
 
         return self.raw.decode(self.charset)
 
     @property
     def raw(self):
-        ''' Data without decoding '''
+        """ Data without decoding """
         pos = self.file.tell()
         self.file.seek(0)
         try:
@@ -331,7 +376,7 @@ class MultipartPart(object):
         return val
 
     def save_as(self, path):
-        fp = open(path, 'wb')
+        fp = open(path, "wb")
         pos = self.file.tell()
         try:
             self.file.seek(0)
@@ -340,12 +385,14 @@ class MultipartPart(object):
             self.file.seek(pos)
         return size
 
+
 ##############################################################################
 #################################### WSGI ####################################
 ##############################################################################
 
-def parse_form_data(environ, charset='utf8', strict=False, **kw):
-    ''' Parse form data from an environ dict and return a (forms, files) tuple.
+
+def parse_form_data(environ, charset="utf8", strict=False, **kw):
+    """ Parse form data from an environ dict and return a (forms, files) tuple.
         Both tuple values are dictionaries with the form-field name as a key
         (unicode) and lists as values (multiple values per key are possible).
         The forms-dictionary contains form-field values as unicode strings.
@@ -357,35 +404,37 @@ def parse_form_data(environ, charset='utf8', strict=False, **kw):
         :param charset: The charset to use if unsure. (default: utf8)
         :param strict: If True, raise :exc:`MultipartError` on any parsing
                        errors. These are silently ignored by default.
-    '''
+    """
 
     forms, files = MultiDict(), MultiDict()
     try:
-        if environ.get('REQUEST_METHOD','GET').upper() not in ('POST', 'PUT'):
+        if environ.get("REQUEST_METHOD", "GET").upper() not in ("POST", "PUT"):
             raise MultipartError("Request method other than POST or PUT.")
-        content_length = int(environ.get('CONTENT_LENGTH', '-1'))
-        content_type = environ.get('CONTENT_TYPE', '')
+        content_length = int(environ.get("CONTENT_LENGTH", "-1"))
+        content_type = environ.get("CONTENT_TYPE", "")
         if not content_type:
             raise MultipartError("Missing Content-Type header.")
         content_type, options = parse_options_header(content_type)
-        stream = environ.get('wsgi.input') or BytesIO()
-        kw['charset'] = charset = options.get('charset', charset)
-        if content_type == 'multipart/form-data':
-            boundary = options.get('boundary','')
+        stream = environ.get("wsgi.input") or BytesIO()
+        kw["charset"] = charset = options.get("charset", charset)
+        if content_type == "multipart/form-data":
+            boundary = options.get("boundary", "")
             if not boundary:
                 raise MultipartError("No boundary for multipart/form-data.")
             for part in MultipartParser(stream, boundary, content_length, **kw):
                 if part.filename or not part.is_buffered():
                     files[part.name] = part
-                else: # TODO: Big form-fields are in the files dict. really?
+                else:  # TODO: Big form-fields are in the files dict. really?
                     forms[part.name] = part.value
-        elif content_type in ('application/x-www-form-urlencoded',
-                              'application/x-url-encoded'):
-            mem_limit = kw.get('mem_limit', 2**20)
+        elif content_type in (
+            "application/x-www-form-urlencoded",
+            "application/x-url-encoded",
+        ):
+            mem_limit = kw.get("mem_limit", 2 ** 20)
             if content_length > mem_limit:
                 raise MultipartError("Request too big. Increase MAXMEM.")
             data = stream.read(mem_limit).decode(charset)
-            if stream.read(1): # These is more that does not fit mem_limit
+            if stream.read(1):  # These is more that does not fit mem_limit
                 raise MultipartError("Request too big. Increase MAXMEM.")
             data = parse_qs(data, keep_blank_values=True)
             for key, values in data.iteritems():
@@ -394,6 +443,6 @@ def parse_form_data(environ, charset='utf8', strict=False, **kw):
         else:
             raise MultipartError("Unsupported content type.")
     except MultipartError:
-        if strict: raise
+        if strict:
+            raise
     return forms, files
-

--- a/multipart.py
+++ b/multipart.py
@@ -6,32 +6,8 @@ Parser for multipart/form-data
 This module provides a parser for the multipart/form-data format. It can read
 from a file, a socket or a WSGI environment. The parser can be used to replace
 cgi.FieldStorage (without the bugs) and works with Python 2.5+ and 3.x (2to3).
-
-Licence (MIT)
--------------
-
-    Copyright (c) 2010, Marcel Hellkamp.
-    Inspired by the Werkzeug library: http://werkzeug.pocoo.org/
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-
 '''
+
 
 __author__ = 'Marcel Hellkamp'
 __version__ = '0.1'
@@ -120,7 +96,7 @@ def header_quote(val):
 def header_unquote(val, filename=False):
     if val[0] == val[-1] == '"':
         val = val[1:-1]
-        if val[1:3] == ':\\' or val[:2] == '\\\\': 
+        if val[1:3] == ':\\' or val[:2] == '\\\\':
             val = val.split('\\')[-1] # fix ie6 bug: full path --> filename
         return val.replace('\\\\','\\').replace('\\"','"')
     return val
@@ -145,13 +121,13 @@ class MultipartError(ValueError): pass
 
 
 class MultipartParser(object):
-    
+
     def __init__(self, stream, boundary, content_length=-1,
                  disk_limit=2**30, mem_limit=2**20, memfile_limit=2**18,
                  buffer_size=2**16, charset='latin1'):
         ''' Parse a multipart/form-data byte stream. This object is an iterator
             over the parts of the message.
-            
+
             :param stream: A file-like stream. Must implement ``.read(size)``.
             :param boundary: The multipart boundary as a byte string.
             :param content_length: The maximum number of bytes to read.
@@ -167,7 +143,7 @@ class MultipartParser(object):
             raise MultipartError('Boundary does not fit into buffer_size.')
         self._done = []
         self._part_iter = None
-    
+
     def __iter__(self):
         ''' Iterate over the parts of the multipart message. '''
         if not self._part_iter:
@@ -177,11 +153,11 @@ class MultipartParser(object):
         for part in self._part_iter:
             self._done.append(part)
             yield part
-    
+
     def parts(self):
         ''' Returns a list with all parts of the multipart message. '''
         return list(iter(self))
-    
+
     def get(self, name, default=None):
         ''' Return the first part with that name or a default value (None). '''
         for part in self:
@@ -231,7 +207,7 @@ class MultipartParser(object):
                 else:                     yield line, _bempty
             if not data:
                 break
-    
+
     def _iterparse(self):
         lines, line = self._lineiter(), ''
         separator = tob('--') + tob(self.boundary)
@@ -269,10 +245,10 @@ class MultipartParser(object):
                     raise MultipartError("Disk limit reached.")
         if line != terminator:
             raise MultipartError("Unexpected end of multipart stream.")
-            
+
 
 class MultipartPart(object):
-    
+
     def __init__(self, buffer_size=2**16, memfile_limit=2**18, charset='latin1'):
         self.headerlist = []
         self.headers = None
@@ -340,7 +316,7 @@ class MultipartPart(object):
         ''' Data decoded with the specified charset '''
 
         return self.raw.decode(self.charset)
-    
+
     @property
     def raw(self):
         ''' Data without decoding '''
@@ -353,7 +329,7 @@ class MultipartPart(object):
         finally:
             self.file.seek(pos)
         return val
-    
+
     def save_as(self, path):
         fp = open(path, 'wb')
         pos = self.file.tell()
@@ -376,13 +352,13 @@ def parse_form_data(environ, charset='utf8', strict=False, **kw):
         The files-dictionary contains :class:`MultipartPart` instances, either
         because the form-field was a file-upload or the value is too big to fit
         into memory limits.
-        
+
         :param environ: An WSGI environment dict.
         :param charset: The charset to use if unsure. (default: utf8)
         :param strict: If True, raise :exc:`MultipartError` on any parsing
                        errors. These are silently ignored by default.
     '''
-        
+
     forms, files = MultiDict(), MultiDict()
     try:
         if environ.get('REQUEST_METHOD','GET').upper() not in ('POST', 'PUT'):

--- a/multipart.py
+++ b/multipart.py
@@ -36,7 +36,11 @@ from collections import MutableMapping as DictMixin
 
 
 class MultiDict(DictMixin):
-    """ A dict that remembers old values for each key """
+    """ A dict that remembers old values for each key.
+        HTTP headers may repeat with differing values,
+        such as Set-Cookie. We need to remember all
+        values.
+    """
 
     def __init__(self, *args, **kwargs):
         self.dict = dict()

--- a/multipart.py
+++ b/multipart.py
@@ -136,13 +136,13 @@ def header_unquote(val, filename=False):
 def parse_options_header(header, options=None):
     if ";" not in header:
         return header.lower().strip(), {}
-    ctype, tail = header.split(";", 1)
+    content_type, tail = header.split(";", 1)
     options = options or {}
     for match in _re_option.finditer(tail):
         key = match.group(1).lower()
         value = header_unquote(match.group(2), key == "filename")
         options[key] = value
-    return ctype, options
+    return content_type, options
 
 
 ##############################################################################
@@ -376,17 +376,16 @@ class MultipartPart(object):
     def finish_header(self):
         self.file = BytesIO()
         self.headers = Headers(self.headerlist)
-        cdis = self.headers.get("Content-Disposition", "")
-        ctype = self.headers.get("Content-Type", "")
-        clen = self.headers.get("Content-Length", "-1")
+        content_disposition = self.headers.get("Content-Disposition", "")
+        content_type = self.headers.get("Content-Type", "")
 
-        if not cdis:
+        if not content_disposition:
             raise MultipartError("Content-Disposition header is missing.")
 
-        self.disposition, self.options = parse_options_header(cdis)
+        self.disposition, self.options = parse_options_header(content_disposition)
         self.name = self.options.get("name")
         self.filename = self.options.get("filename")
-        self.content_type, options = parse_options_header(ctype)
+        self.content_type, options = parse_options_header(content_type)
         self.charset = options.get("charset") or self.charset
         self.content_length = int(self.headers.get("Content-Length", "-1"))
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,16 +1,11 @@
 rm -r ./test.run &>/dev/null
 cp -r ./test ./test.run
-cp ./src/* ./test.run/
 cd test.run
 
 coverage run ./test.py
 coverage combine
 coverage report
 coverage html -i -d ../html
-
-echo
-echo "2to3 ..."
-2to3 -w *.py &> /dev/null
 
 python3 ./test.py
 

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,10 @@ import sys
 import os.path
 from distutils.core import setup
 
-if sys.version_info < (2,5):
-    raise NotImplementedError("Sorry, you need at least Python 2.5 or Python 3.x to use this module.")
+if sys.version_info < (2, 5):
+    raise NotImplementedError(
+        "Sorry, you need at least Python 2.5 or Python 3.x to use this module."
+    )
 
 try:
     from distutils.command.build_py import build_py_2to3 as build_py
@@ -14,29 +16,29 @@ except ImportError:
 
 from multipart import __version__, __author__, __license__, __doc__
 
-setup(name='multipart',
-      version = __version__,
-      description = 'Parser for multipart/form-data.',
-      long_description = __doc__,
-      author = __author__,
-      author_email = 'marc@gsites.de',
-      url = 'http://github.com/defnull/multipart',
-      py_modules = ['multipart'],
-      license = __license__,
-      platforms = 'any',
-      classifiers = ['Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: CGI Tools/Libraries',
-        'Topic :: Internet :: WWW/HTTP :: HTTP Servers',
-        'Topic :: Internet :: WWW/HTTP :: WSGI',
-        'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',
-        'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware',
-        'Topic :: Internet :: WWW/HTTP :: WSGI :: Server',
-        'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 3'],
-      cmdclass = {'build_py': build_py}
-     )
-
-
-
+setup(
+    name="multipart",
+    version=__version__,
+    description="Parser for multipart/form-data.",
+    long_description=__doc__,
+    author=__author__,
+    author_email="marc@gsites.de",
+    url="http://github.com/defnull/multipart",
+    py_modules=["multipart"],
+    license=__license__,
+    platforms="any",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: CGI Tools/Libraries",
+        "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
+        "Topic :: Internet :: WWW/HTTP :: WSGI",
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware",
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Server",
+        "Programming Language :: Python :: 2.5",
+        "Programming Language :: Python :: 3",
+    ],
+    cmdclass={"build_py": build_py},
+)

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,7 @@
 
 import sys
 import os.path
-from distutils.core import setup
-
-if sys.version_info < (2, 5):
-    raise NotImplementedError(
-        "Sorry, you need at least Python 2.5 or Python 3.x to use this module."
-    )
-
-try:
-    from distutils.command.build_py import build_py_2to3 as build_py
-except ImportError:
-    from distutils.command.build_py import build_py
+from setuptools import setup
 
 from multipart import __version__, __author__, __license__, __doc__
 
@@ -40,5 +30,4 @@ setup(
         "Programming Language :: Python :: 2.5",
         "Programming Language :: Python :: 3",
     ],
-    cmdclass={"build_py": build_py},
 )

--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 import unittest
-import sys, os.path, tempfile
-import multipart as mp
-from multipart import to_bytes
 import base64
+import sys, os.path, tempfile
+
+from io import BytesIO
+
 try:
-    from io import BytesIO
-except ImportError:
-    from StringIO import StringIO as BytesIO
+    import multipart as mp
+except ModuleNotFoundError:
+    raise SystemExit("multipart not resolveable. Try 'python setup.py develop'.")
+
+from multipart import to_bytes
 
 #TODO: bufsize=10, line=1234567890--boundary\n
 #TODO: bufsize < len(boundary) (should not be possible)


### PR DESCRIPTION
The commits are *fairly* atomic, aside from the giant reformatting pass. Due to this, the diffs are not particularly nice to read. I'd recommend simply reading the files in their new state to review, combined with checking each commit of substance. The commits are readable enough in themselves.

I know you didn't feel there was a need to do a general formatting pass, but it really was quite unpleasant to read so I blacked the code anyway. There were lumps of 20+ lines with varying indentations and amounts of complexity all on top of each other. Same goes for some variable names like ctype. No reason to have `content_type` shortened to `ctype`. I still have no idea what `nl` means, so I'd recommend expanding that one yourself. New Line? Anyway - there were formatting changes. I'm not saying that a pass with black should be a requirement, but just that it was used to give the codebase a spring cleaning.

> Automated tools do not see context, and will enforce pep-8 even in situations where it makes the code worse.

In this case, I think there were no cases where the code was made worse.

Things I didn't do but would like, with discussion:
* There probably should be any file io going on in a parser. Makes it hard to decouple for other io options (async).
* The test running script should probably just be scrapped.