### PR TITLE
multipart: empty payload support implemented

### DIFF
--- a/multipart.py
+++ b/multipart.py
@@ -283,7 +283,7 @@ class MultipartParser(object):
 
         # Check for empty data
         if line == terminator:
-            for line, nl in lines:
+            for _ in lines:
                 raise MultipartError("Data after end of stream")
             return
 

--- a/multipart.py
+++ b/multipart.py
@@ -10,7 +10,7 @@ cgi.FieldStorage (without the bugs) and works with Python 2.5+ and 3.x (2to3).
 
 
 __author__ = "Marcel Hellkamp"
-__version__ = "0.2"
+__version__ = "0.2.1"
 __license__ = "MIT"
 __all__ = ["MultipartError", "MultipartParser", "MultipartPart", "parse_form_data"]
 
@@ -280,6 +280,12 @@ class MultipartParser(object):
         for line, nl in lines:
             if line:
                 break
+
+        # Check for empty data
+        if line == terminator:
+            for line, nl in lines:
+                raise MultipartError("Data after end of stream")
+            return
 
         if line != separator:
             raise MultipartError("Stream does not start with boundary")

--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -221,6 +221,11 @@ class TestFormParser(unittest.TestCase):
        self.assertEqual(files['file1'].name, 'file1')
        self.assertEqual(files['file1'].content_type, 'image/png')
 
+    def test_empty(self):
+        forms, files = self.parse('--foo--\r\n')
+        self.assertEqual(0, len(forms))
+        self.assertEqual(0, len(files))
+
     def test_urlencoded(self):
        for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
            self.env['CONTENT_TYPE'] = ctype


### PR DESCRIPTION
Added support for the empty multipart payload. Here is an example of a valid empty payload:

`--theboundary--\r\n`

All the tests are passed. Reach out to me if any additional tests are required.

With this addition `multipart` package works perfectly for me.

Please approve and publish a new version to PyPI. Thank you for the useful package!