### PR TITLE
Use NamedTemporaryFile for large file uploads

### DIFF
--- a/multipart.py
+++ b/multipart.py
@@ -18,7 +18,7 @@ __all__ = ["MultipartError", "MultipartParser", "MultipartPart", "parse_form_dat
 import re
 import sys
 from io import BytesIO
-from tempfile import TemporaryFile
+from tempfile import NamedTemporaryFile
 from urllib.parse import parse_qs
 from wsgiref.headers import Headers
 from collections import MutableMapping as DictMixin
@@ -385,7 +385,7 @@ class MultipartPart(object):
 
         if self.size > self.memfile_limit and isinstance(self.file, BytesIO):
             # TODO: What about non-file uploads that exceed the memfile_limit?
-            self.file, old = TemporaryFile(mode="w+b"), self.file
+            self.file, old = NamedTemporaryFile(mode="w+b"), self.file
             old.seek(0)
             copy_file(old, self.file, self.size, self.buffer_size)
 

--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -103,8 +103,10 @@ class TestMultipartParser(unittest.TestCase):
         self.assertTrue(p.get('file1').is_buffered())
         self.assertEqual(p.get('file2').file.read(), to_bytes(test_file + 'a'))
         self.assertFalse(p.get('file2').is_buffered())
+        self.assertIsInstance(p.get('file2').file.name, str)
         self.assertEqual(p.get('file3').file.read(), to_bytes(test_file*2))
         self.assertFalse(p.get('file3').is_buffered())
+        self.assertIsInstance(p.get('file3').file.name, str)
 
     def test_get_all(self):
         ''' Test the get() and get_all() methods. '''


### PR DESCRIPTION
I'm considering porting zope.publisher from cgi.FieldStorage to
multipart (see
https://github.com/zopefoundation/zope.publisher/issues/39).  This seems
reasonably practical, except that zope.publisher currently relies on
subclassing cgi.FieldStorage with a make_file method that returns a
NamedTemporaryFile rather than a TemporaryFile.  There doesn't seem a
particular reason why multipart couldn't just use a NamedTemporaryFile
instead.

zope.publisher still supports Python 2, so for Python 2 compatibility
it'll be necessary to monkey-patch this (unless you're willing to
maintain a 0.1.x branch), but in the long term it would be good to be
able to drop the monkey-patch.