### PR TITLE
Import MutableMapping from collections.abc

### DIFF
--- a/multipart.py
+++ b/multipart.py
@@ -21,7 +21,7 @@ from io import BytesIO
 from tempfile import TemporaryFile
 from urllib.parse import parse_qs
 from wsgiref.headers import Headers
-from collections import MutableMapping as DictMixin
+from collections.abc import MutableMapping as DictMixin
 
 
 ##############################################################################


### PR DESCRIPTION
This exists as of Python 3.3, and multipart >= 0.2 only supports 3.6 and
up.  The old import path produces a DeprecationWarning on Python >= 3.7.