### PR TITLE
Add tox and GitHub Actions configuration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on: [push, pull_request]
+
+jobs:
+  testing:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [2.7]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip tox
+
+    - name: Test
+      run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist =
+    py27
+
+[testenv]
+deps =
+    .
+    pytest
+commands =
+    pytest


### PR DESCRIPTION
This gives us CI that runs automatically on pushes and PRs.

This is the same as #26, except I've proposed it against a new "0.1" branch, making it reasonable for us to produce 0.1.x maintenance releases for Python 2; I'm not expecting many of these since Python 2 is EOL, but as noted in #25 there are some cases where it would be very helpful for dependent projects.