### PR TITLE
Consistently decode URL-encoded form data

### DIFF
--- a/multipart.py
+++ b/multipart.py
@@ -517,7 +517,7 @@ def parse_form_data(environ, charset="utf8", strict=False, **kwargs):
             if stream.read(1):  # These is more that does not fit mem_limit
                 raise MultipartError("Request too big. Increase MAXMEM.")
 
-            data = parse_qs(data, keep_blank_values=True)
+            data = parse_qs(data, keep_blank_values=True, encoding=charset)
 
             for key, values in data.items():
                 for value in values:

--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -210,7 +210,7 @@ class TestFormParser(unittest.TestCase):
         self.data.seek(0)
         kwargs['environ'] = self.env
         kwargs['strict'] = True
-        kwargs['charset'] = 'utf8'
+        kwargs.setdefault('charset', 'utf8')
         return mp.parse_form_data(**kwargs)
 
     def test_multipart(self):
@@ -231,12 +231,26 @@ class TestFormParser(unittest.TestCase):
         self.assertEqual(0, len(files))
 
     def test_urlencoded(self):
-       for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
-           self.env['CONTENT_TYPE'] = ctype
-           forms, files = self.parse('a=b&c=d;e=f')
-           self.assertEqual(forms['a'], 'b')
-           self.assertEqual(forms['c'], 'd')
-           self.assertEqual(forms['e'], 'f')
+        for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
+            self.env['CONTENT_TYPE'] = ctype
+            forms, files = self.parse('a=b&c=d;e=f')
+            self.assertEqual(forms['a'], 'b')
+            self.assertEqual(forms['c'], 'd')
+            self.assertEqual(forms['e'], 'f')
+
+    def test_urlencoded_latin1(self):
+        for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
+            self.env['CONTENT_TYPE'] = ctype
+            forms, files = self.parse(b'a=\xe0\xe1&e=%E8%E9', charset='iso-8859-1')
+            self.assertEqual(forms['a'], 'àá')
+            self.assertEqual(forms['e'], 'èé')
+
+    def test_urlencoded_utf8(self):
+        for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
+            self.env['CONTENT_TYPE'] = ctype
+            forms, files = self.parse(b'a=\xc6\x80\xe2\x99\xad&e=%E1%B8%9F%E2%99%AE')
+            self.assertEqual(forms['a'], 'ƀ♭')
+            self.assertEqual(forms['e'], 'ḟ♮')
 
 
 class TestBrokenMultipart(unittest.TestCase):


### PR DESCRIPTION
It's confusing for raw bytes and percent-encoded bytes in URL-encoded
form data to be decoded using different character sets; this happened if
passing a `charset` parameter other than "utf8" to `parse_form_data`.

https://url.spec.whatwg.org/#application/x-www-form-urlencoded
intentionally doesn't cover non-UTF-8 cases, but it explicitly says that
a parser should perform bytewise percent-decoding followed by UTF-8
decoding; the design of Python's `parse_qs` means that we have to do
this the other way round, but nevertheless, if something other than
UTF-8 decoding has been explicitly requested then it seems to fit the
specification better to use the same character set for interpreting raw
bytes and for interpreting percent-encoded sequences.

This came up when porting Launchpad to Python 3, because (I assume for
historical reasons) zope.publisher deliberately interprets form data
using ISO-8859-1 on round-tripping grounds and then re-decodes that to
the preferred character set of the request, which is pretty confusing at
the best of times but in particular went wrong when given form values
that have been UTF-8-encoded and then percent-encoded.