### PR TITLE
Add python-requires directive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [metadata]
 license_file = LICENSE
 
+[options]
+python_requires = >=3.5
+
 [tool:pytest]
 minversion = 3.0
 testpaths = test


### PR DESCRIPTION
Indicating Python version required and preventing older Pythons from attempting to download this version. Fixes #31.
