### PR TITLE
Don't test semicolon separators in urlencoded data

### DIFF
--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -233,10 +233,9 @@ class TestFormParser(unittest.TestCase):
     def test_urlencoded(self):
         for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
             self.env['CONTENT_TYPE'] = ctype
-            forms, files = self.parse('a=b&c=d;e=f')
+            forms, files = self.parse('a=b&c=d')
             self.assertEqual(forms['a'], 'b')
             self.assertEqual(forms['c'], 'd')
-            self.assertEqual(forms['e'], 'f')
 
     def test_urlencoded_latin1(self):
         for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):


### PR DESCRIPTION
Python no longer accepts ";" as a separator for `urllib.parse.parse_qs`
by default (https://bugs.python.org/issue42967), causing the multipart
test suite to fail with recent Python versions (3.6.13, 3.7.10, 3.8.8,
3.9.2, 3.10.0a6).

While we could detect the availability of the `separator` argument and
pass it, since `application/x-www-form-urlencoded` data in `POST` and
`PUT` requests is probably not an issue for web cache poisoning, the
current HTML spec seems clear that only "&" should be considered, so
follow along with Python's API change.