### PR TITLE
Consistently decode URL-encoded form data

### DIFF
--- a/multipart.py
+++ b/multipart.py
@@ -400,13 +400,13 @@ def parse_form_data(environ, charset='utf8', strict=False, **kw):
             mem_limit = kw.get('mem_limit', 2**20)
             if content_length > mem_limit:
                 raise MultipartError("Request to big. Increase MAXMEM.")
-            data = stream.read(mem_limit).decode(charset)
+            data = stream.read(mem_limit)
             if stream.read(1): # These is more that does not fit mem_limit
                 raise MultipartError("Request to big. Increase MAXMEM.")
             data = parse_qs(data, keep_blank_values=True)
             for key, values in data.iteritems():
                 for value in values:
-                    forms[key] = value
+                    forms[key] = value.decode(charset)
         else:
             raise MultipartError("Unsupported content type.")
     except MultipartError:

--- a/multipart.py
+++ b/multipart.py
@@ -406,7 +406,7 @@ def parse_form_data(environ, charset='utf8', strict=False, **kw):
             data = parse_qs(data, keep_blank_values=True)
             for key, values in data.iteritems():
                 for value in values:
-                    forms[key] = value.decode(charset)
+                    forms[key.decode(charset)] = value.decode(charset)
         else:
             raise MultipartError("Unsupported content type.")
     except MultipartError:

--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -236,9 +236,10 @@ class TestFormParser(unittest.TestCase):
     def test_urlencoded_utf8(self):
         for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
             self.env['CONTENT_TYPE'] = ctype
-            forms, files = self.parse(b'a=\xc6\x80\xe2\x99\xad&e=%E1%B8%9F%E2%99%AE')
-            self.assertEqual(forms['a'], u'ƀ♭')
-            self.assertEqual(forms['e'], u'ḟ♮')
+            forms, files = self.parse(
+                b'\xce\xb1=\xc6\x80\xe2\x99\xad&%CE%B5=%E1%B8%9F%E2%99%AE')
+            self.assertEqual(forms[u'α'], u'ƀ♭')
+            self.assertEqual(forms[u'ε'], u'ḟ♮')
 
 
 class TestBrokenMultipart(unittest.TestCase):

--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -203,7 +203,7 @@ class TestFormParser(unittest.TestCase):
         self.data.seek(0)
         kwargs['environ'] = self.env
         kwargs['strict'] = True
-        kwargs['charset'] = 'utf8'
+        kwargs.setdefault('charset', 'utf8')
         return mp.parse_form_data(**kwargs)
     
     def test_multipart(self):
@@ -219,12 +219,26 @@ class TestFormParser(unittest.TestCase):
        self.assertEqual(files['file1'].content_type, 'image/png')
 
     def test_urlencoded(self):
-       for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
-           self.env['CONTENT_TYPE'] = ctype
-           forms, files = self.parse('a=b&c=d;e=f')
-           self.assertEqual(forms['a'], 'b')
-           self.assertEqual(forms['c'], 'd')
-           self.assertEqual(forms['e'], 'f')
+        for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
+            self.env['CONTENT_TYPE'] = ctype
+            forms, files = self.parse('a=b&c=d;e=f')
+            self.assertEqual(forms['a'], 'b')
+            self.assertEqual(forms['c'], 'd')
+            self.assertEqual(forms['e'], 'f')
+
+    def test_urlencoded_latin1(self):
+        for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
+            self.env['CONTENT_TYPE'] = ctype
+            forms, files = self.parse(b'a=\xe0\xe1&e=%E8%E9', charset='iso-8859-1')
+            self.assertEqual(forms['a'], u'àá')
+            self.assertEqual(forms['e'], u'èé')
+
+    def test_urlencoded_utf8(self):
+        for ctype in ('application/x-www-form-urlencoded', 'application/x-url-encoded'):
+            self.env['CONTENT_TYPE'] = ctype
+            forms, files = self.parse(b'a=\xc6\x80\xe2\x99\xad&e=%E1%B8%9F%E2%99%AE')
+            self.assertEqual(forms['a'], u'ƀ♭')
+            self.assertEqual(forms['e'], u'ḟ♮')
 
 
 class TestBrokenMultipart(unittest.TestCase):


### PR DESCRIPTION
It's confusing for raw bytes and percent-encoded bytes in URL-encoded
form data to be decoded using different character sets; this happened if
passing a `charset` parameter other than "latin1" to `parse_form_data`.

https://url.spec.whatwg.org/#application/x-www-form-urlencoded
intentionally doesn't cover non-UTF-8 cases, but it explicitly says that
a parser should perform bytewise percent-decoding followed by UTF-8
decoding, so we might infer that we should do something analogous for
whatever `charset` is specified.  However, Python 2's `unquote` (called
by `parse_qs` unconditionally decodes as ISO-8859-1 if called with
Unicode input that contains percent-encoded sequences.  To work around
this, make sure to call it with bytes input, and then decode the
individual values ourselves.

This is similar to #30, with corresponding test cases, but the details
are different for Python 2.  This was noticed by the Launchpad test
suite after applying the changes from
https://github.com/zopefoundation/zope.publisher/pull/66 (although it
was a problem before that, just masked).