### PR TITLE
Replace obsolete URL with current one for Bottle

### DIFF
--- a/multipart.py
+++ b/multipart.py
@@ -27,7 +27,7 @@ from collections.abc import MutableMapping as DictMixin
 ##############################################################################
 ################################ Helper & Misc ###############################
 ##############################################################################
-# Some of these were copied from bottle: http://bottle.paws.de/
+# Some of these were copied from bottle: https://bottlepy.org
 
 
 # ---------


### PR DESCRIPTION
The URL http://bottle.paws.de is a dead link. The project has moved its home page to https://bottle.org.

I figured this change is too trivial to warrant a bug report. If you disagree I'll be happy to create one.