### PR TITLE
New push based (non-blocking) parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,18 @@
 Parser for multipart/form-data
 ==============================
 
+.. image:: https://github.com/defnull/multipart/actions/workflows/test.yaml/badge.svg
+    :target: https://github.com/defnull/multipart/actions/workflows/test.yaml
+    :alt: Tests Status
+
+.. image:: https://img.shields.io/pypi/v/multipart.svg
+    :target: https://pypi.python.org/pypi/multipart/
+    :alt: Latest Version
+
+.. image:: https://img.shields.io/pypi/l/multipart.svg
+    :target: https://pypi.python.org/pypi/multipart/
+    :alt: License
+
 This module provides multiple parsers for RFC-7578 ``multipart/form-data``, both
 low-level for framework authors and high-level for WSGI application developers:
 

--- a/README.rst
+++ b/README.rst
@@ -1,38 +1,129 @@
 Parser for multipart/form-data
 ==============================
 
-This module provides a parser for the multipart/form-data format. It can read
-from a file, a socket or a WSGI environment. The parser can be used to replace
-cgi.FieldStorage to work around its limitations.
+This module provides multiple parsers for RFC-7578 ``multipart/form-data``, both
+low-level for framework authors and high-level for WSGI application developers:
+
+* ``PushMultipartParser``: A low-level incremental `SansIO <https://sans-io.readthedocs.io/>`_
+  (non-blocking) parser suitable for asyncio and other time or memory constrained
+  environments.
+* ``MultipartParser``: A streaming parser emitting memory- and disk-buffered
+  ``MultipartPart`` instances.
+* ``parse_form_data``: A helper function to parse both ``multipart/form-data``
+  and ``application/x-www-form-urlencoded`` form submissions from a
+  `WSGI <https://peps.python.org/pep-3333/>`_ environment.
+
+Installation
+------------
+
+``pip install multipart``
 
 Features
 --------
 
-* Parses ``multipart/form-data`` and ``application/x-www-form-urlencoded``.
-* Produces useful error messages in 'strict'-mode.
-* Gracefully handle uploads of unknown size (missing ``Content-Length`` header).
-* Fast memory mapped files (io.BytesIO) for small uploads.
-* Temporary files on disk for big uploads.
-* Memory and disk resource limits to prevent DOS attacks.
-* Fixes many shortcomings and bugs of ``cgi.FieldStorage``.
-* 100% test coverage.
+* Pure python single file module with no dependencies.
+* 100% test coverage. Tested with inputs as seen from actual browsers and HTTP clients.
+* Parses multiple GB/s on modern hardware (quick tests, no proper benchmark).
+* Quickly rejects malicious or broken inputs and emits useful error messages.
+* Enforces configurable memory and disk resource limits to prevent DoS attacks.
 
-Limitations
------------
+**Limitations:** This parser implements ``multipart/form-data`` as it is used by
+actual modern browsers and HTTP clients, which means:
 
-* Only parses ``multipart/form-data`` as seen from actual browsers.
+* Just ``multipart/form-data``, not suitable for email parsing
+* No ``multipart/mixed`` support (RFC 2388, deprecated in RFC 7578)
+* No ``encoded-word`` encoding (RFC 2047, no one uses that)
+* No ``base64`` or ``quoted-printable`` transfer encoding (not used)
+* No ``name=_charset_`` support (discouraged in RFC 7578)
 
-  * Not suitable as a general purpose multipart parser (e.g. for multipart emails).
-  * No ``multipart/mixed`` support (RFC 2388, deprecated in RFC 7578)
-  * No ``encoded-word`` encoding (RFC 2047).
-  * No ``base64`` or ``quoted-printable`` transfer encoding.
-  
-* Part headers are expected to be encoded in the charset given to the ``Multipart``/``MultipartParser`` constructor.
-  [For operability considerations, see RFC 7578, section 5.1.]
-* The size of headers are not counted against the in-memory limit (todo).
+Usage and examples
+------------------
+
+For WSGI application developers we strongly suggest using the ``parse_form_data``
+helper function. It accepts a WSGI ``environ`` dictionary and parses both types
+of form submission (``multipart/form-data`` and ``application/x-www-form-urlencoded``)
+based on the actual content type of the request. You'll get two ``MultiDict``
+instances in return, one for text fields and the other for file uploads:
+
+.. code-block:: python
+
+    from multipart import parse_form_data
+
+    def wsgi(environ, start_response):
+      if environ["REQUEST_METHOD"] == "POST":
+        forms, files = parse_form_data(environ)
+        
+        title = forms["title"]    # string
+        upload = files["upload"]  # MultipartPart
+        upload.save_as(...)
+
+The ``parse_form_data`` helper function internally uses ``MultipartParser``, a
+streaming parser that reads from a ``multipart/form-data`` encoded binary data
+stream and emits ``MultipartPart`` instances as soon as a part is fully parsed.
+This is most useful if you want to consume the individual parts as soon as they
+arrive, instead of waiting for the entire request to be parsed:
+
+.. code-block:: python
+
+    from multipart import parse_options_header, MultipartParser
+
+    def wsgi(environ, start_response):
+      assert environ["REQUEST_METHOD"] == "POST"
+      ctype, copts = mp.parse_options_header(environ.get("CONTENT_TYPE", ""))
+      boundary = copts.get("boundary")
+      charset = copts.get("charset", "utf8")
+      assert ctype == "multipart/form-data"
+    
+      parser = mp.MultipartParser(environ["wsgi.input"], boundary, charset)
+      for part in parser:
+        if part.filename:
+          print(f"{part.name}: File upload ({part.size} bytes)")
+          part.save_as(...)
+        elif part.size < 1024:
+          print(f"{part.name}: Text field ({part.value!r})")
+        else:
+          print(f"{part.name}: Test field, but too big to print :/")
+
+The ``MultipartParser`` handles IO and file buffering for you, but does so using
+blocking APIs. If you need absolute control over the parsing process and want to
+avoid blocking IO at all cost, then have a look at ``PushMultipartParser``, the
+low-level non-blocking incremental ``multipart/form-data`` parser that powers all
+the other parsers in this library:
+
+.. code-block:: python
+
+    from multipart import PushMultipartParser
+
+    async def process_multipart(reader: asyncio.StreamReader, boundary: str):
+      with PushMultipartParser(boundary) as parser:
+        while not parser.closed:
+          chunk = await reader.read(1024*46)
+          for event in parser.parse(chunk):
+            if isinstance(event, list):
+              print("== Start of segment")
+              for header, value in event:
+                print(f"{header}: {value}")
+            elif isinstance(event, bytearray):
+              print(f"[{len(event)} bytes of data]")
+            elif event is None:
+              print("== End of segment")
+
 
 Changelog
 ---------
+
+* **1.0 (TBC)**
+
+  * A completely new, fast, non-blocking ``PushMultipartParser`` parser, which
+    now serves as the basis for all other parsers.
+  * Default charset for ``MultipartParser`` headers and text fields changed to
+    ``utf8``.
+  * Default disk and memory limits for ``MultipartParser`` increased, and
+    multiple other limits added for finer control.
+  * Undocumented APIs deprecated or removed, some of which were not strictly
+    private. This includes parameters for ``MultipartParser``, some
+    ``MultipartPart`` methods that should not be used by anyone but the parser
+    itself.
 
 * **0.2.5 (18.06.2024)**
 

--- a/test/test_multdict.py
+++ b/test/test_multdict.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
-import os.path, tempfile
-
 import multipart as mp
+
 
 class testMultiDict(unittest.TestCase):
 
@@ -49,4 +48,4 @@ class testMultiDict(unittest.TestCase):
     def test_access_all(self):
         md = mp.MultiDict([("a", "1"), ("a", "2")])
         self.assertEqual(md.getall("a"), ["1", "2"])
-        self.assertEqual(list(md.iterallitems()), [("a", "1"),("a", "2")])
+        self.assertEqual(list(md.iterallitems()), [("a", "1"), ("a", "2")])

--- a/test/test_multipart.py
+++ b/test/test_multipart.py
@@ -41,39 +41,6 @@ class TestHeaderParser(unittest.TestCase):
 
 class TestMultipartParser(unittest.TestCase):
 
-    def test_line_parser(self):
-        for line in ('foo',''):
-            for ending in ('\n','\r','\r\n'):
-                i = mp.MultipartParser(BytesIO(to_bytes(line+ending)), 'foo')
-                i = next(i._lineiter())
-                self.assertEqual(i, (to_bytes(line), to_bytes(ending)))
-
-    def test_iterlines(self):
-        data = 'abc\ndef\r\nghi'
-        result = [(to_bytes('abc'),to_bytes('\n')),(to_bytes('def'),to_bytes('\r\n')),(to_bytes('ghi'),to_bytes(''))]
-        i = mp.MultipartParser(BytesIO(to_bytes(data)), 'foo')._lineiter()
-        self.assertEqual(list(i), result)
-
-    def test_iterlines_limit(self):
-        data, limit = 'abc\ndef\r\nghi', 10
-        result = [(to_bytes('abc'),to_bytes('\n')),(to_bytes('def'),to_bytes('\r\n')),(to_bytes('g'),to_bytes(''))]
-        i = mp.MultipartParser(BytesIO(to_bytes(data)), 'foo', limit)._lineiter()
-        self.assertEqual(list(i), result)
-        data, limit = 'abc\ndef\r\nghi', 8
-        result = [(to_bytes('abc'),to_bytes('\n')),(to_bytes('def'),to_bytes('\r'))]
-        i = mp.MultipartParser(BytesIO(to_bytes(data)), 'foo', limit)._lineiter()
-        self.assertEqual(list(i), result)
-
-    def test_iterlines_maxbuf(self):
-        data, limit = 'abcdefgh\nijklmnop\r\nq', 9
-        result = [(to_bytes('abcdefgh'),to_bytes('\n')),(to_bytes('ijklmnop'),to_bytes('')),(to_bytes(''),to_bytes('\r\n')),(to_bytes('q'),to_bytes(''))]
-        i = mp.MultipartParser(BytesIO(to_bytes(data)), 'foo', buffer_size=limit)._lineiter()
-        self.assertEqual(list(i), result)
-        data, limit = ('X'*3*1024)+'x\n', 1024
-        result = [(to_bytes('X'*1024),to_bytes('')),(to_bytes('X'*1024),to_bytes('')),(to_bytes('X'*1024),to_bytes('')),(to_bytes('x'),to_bytes('\n'))]
-        i = mp.MultipartParser(BytesIO(to_bytes(data)), 'foo', buffer_size=limit)._lineiter()
-        self.assertEqual(list(i), result)
-
     def test_copyfile(self):
         source = BytesIO(to_bytes('abc'))
         target = BytesIO()
@@ -380,7 +347,7 @@ class TestBrokenMultipart(unittest.TestCase):
         self.write('--foo\r\n',
                    'Content-Disposition: form-data; name="file1"; filename="random.png"\r\n',
                    'Content-Type: image/png\r\n', '\r\n', 'abc'*1024+'\r\n', '--foo--')
-        self.assertMPError(memfile_limit=0, disk_limit=1024)
+        self.assertMPError(memfile_limit=1, disk_limit=1024)
 
     def test_mem_limit(self):
         self.write('--foo\r\n',
@@ -423,7 +390,7 @@ class TestBrokenMultipart(unittest.TestCase):
 
 ''' The files used by the following test were taken from the werkzeug library
     test suite and are therefore partly copyrighted by the Werkzeug Team
-    under BSD licence. See http://werkzeug.pocoo.org/ '''
+    under BSD licence. See https://werkzeug.palletsprojects.com/ '''
 
 browser_test_cases = {}
 browser_test_cases['firefox3-2png1txt'] = {'data': base64.b64decode(to_bytes('''

--- a/test/test_push_parser.py
+++ b/test/test_push_parser.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+from contextlib import contextmanager
+import unittest
+import multipart as mp
+
+
+def assertStrict(text):
+    def decorator(func):
+        def wrapper(self):
+            func(self, strict=False)
+            with self.assertRaisesRegex(mp.MultipartError, text):
+                func(self, strict=True)
+
+        return wrapper
+
+    return decorator
+
+
+class TestPushParser(unittest.TestCase):
+
+    def setUp(self):
+        self.reset(boundary="boundary")
+        self.parts = []
+
+    @contextmanager
+    def assertMPE(self, text):
+        with self.assertRaises(mp.MultipartError) as r:
+            yield
+        fullmsg = " ".join(map(str, r.exception.args))
+        self.assertTrue(text in fullmsg, f"{text!r} not in {fullmsg!r}")
+
+    def reset(self, **ka):
+        ka.setdefault("boundary", "boundary")
+        self.parser = mp.PushMultipartParser(**ka)
+        self.parts = []
+
+    def parse(self, data):
+        self.parts = list(self.parser.parse(data))
+        return self.parts
+
+    def test_data_after_terminator(self):
+        self.parse(b"--boundary--")
+        self.parse(b"junk")  # Fine
+
+        self.reset(strict=True)
+        self.parse(b"--boundary--")
+        with self.assertRaises(mp.MultipartError):
+            self.parse(b"junk")
+
+    def test_eof_before_clen(self):
+        self.reset(content_length=100)
+        self.parse(b"--boundary")
+        with self.assertMPE("Unexpected end of multipart stream (parser closed)"):
+            self.parse(b"")
+
+    def test_data_after_eof(self):
+        self.parse(b"--boundary--")
+        assert self.parser._state == mp._COMPLETE
+        assert not self.parser.closed
+
+        self.parse(b"")
+        assert self.parser.closed
+
+        with self.assertMPE("Parser closed"):
+            self.parse(b"junk")
+
+    def test_eof_before_terminator(self):
+        self.parse(b"--boundary")
+        with self.assertMPE("Unexpected end of multipart stream"):
+            self.parse(b"")
+
+    def test_data_after_clen(self):
+        self.reset(content_length=12)
+        with self.assertMPE("Content-Length limit exceeded"):
+            self.parse(b"--boundary\r\njunk")
+
+    def test_clen_match(self):
+        self.reset(content_length=12)
+        self.parse(b"--boundary--")
+        assert self.parser._state is mp._COMPLETE
+
+    @assertStrict("Unexpected data in front of first delimiter")
+    def test_junk_before(self, strict):
+        self.reset(strict=strict)
+        self.parse(b"junk--boundary--")
+
+    @assertStrict("Unexpected data after end of multipart stream")
+    def test_junk_after(self, strict):
+        self.reset(strict=strict)
+        self.parse(b"--boundary--")
+        self.parse(b"junk")
+
+    def test_close_before_end(self):
+        self.parse(b"--boundary")
+        with self.assertMPE("Unexpected end of multipart stream"):
+            self.parser.close()
+
+    def test_header_size_limit(self):
+        self.reset(max_header_size=1024)
+        self.parse(b"--boundary\r\n")
+        with self.assertMPE("Maximum segment header length exceeded"):
+            self.parse(b"Header: " + b"x" * (1024))
+
+        self.reset(max_header_size=1024, strict=True)
+        self.parse(b"--boundary\r\n")
+        with self.assertRaisesRegex(
+            mp.MultipartError, "Maximum segment header length exceeded"
+        ):
+            self.parse(b"Header: " + b"x" * (1024) + b"\r\n")
+
+    def test_header_count_limit(self):
+        self.reset(max_header_count=10)
+        self.parse(b"--boundary\r\n")
+        for i in range(10):
+            self.parse(b"Header: value\r\n")
+        with self.assertMPE("Maximum segment header count exceeded"):
+            self.parse(b"Header: value\r\n")
+
+    @assertStrict("Unexpected segment header continuation")
+    def test_header_continuation(self, strict):
+        self.reset(strict=strict)
+        self.parse(b"--boundary\r\n")
+        self.parse(b"Content-Disposition: form-data;\r\n")
+        self.parse(b'\tname="foo"\r\n')
+        parts = self.parse(b"\r\ndata\r\n--boundary--")
+        self.assertEqual(
+            [("Content-Disposition", 'form-data; name="foo"')], parts[0].headerlist
+        )
+        self.assertEqual(b"data", parts[1])
+
+    def test_header_continuation_first(self):
+        self.parse(b"--boundary\r\n")
+        with self.assertMPE("Unexpected segment header continuation"):
+            self.parse(b"\tbad: header\r\n\r\ndata\r\n--boundary--")
+
+    def test_header_continuation_long(self):
+        self.reset(max_header_size=1024)
+        self.parse(b"--boundary\r\n")
+        self.parse(b"Header: " + b"v" * 1000 + b"\r\n")
+        with self.assertMPE("Maximum segment header length exceeded"):
+            self.parse(b"\tmoooooooooooooooooooooooooore value\r\n")
+
+    def test_header_bad_name(self):
+        self.reset()
+        with self.assertMPE("Malformed segment header"):
+            self.parse(b"--boundary\r\nno-colon\r\n\r\ndata\r\n--boundary--")
+        self.reset()
+        with self.assertMPE("Malformed segment header"):
+            self.parse(b"--boundary\r\n:empty-name\r\n\r\ndata\r\n--boundary--")
+        for badchar in (b" ", b"\0", b"\r", b"\n", "ö".encode("utf8")):
+            self.reset()
+            with self.assertMPE("Invalid segment header name"):
+                self.parse(
+                    b"--boundary\r\ninvalid%sname:value\r\n\r\ndata\r\n--boundary--"
+                    % badchar
+                )
+        self.reset()
+        with self.assertMPE("Segment header failed to decode"):
+            self.parse(
+                b"--boundary\r\ninvalid\xc3\x28:value\r\n\r\ndata\r\n--boundary--"
+            )
+
+    def test_header_bad_disposition(self):
+        with self.assertMPE("Invalid Content-Disposition segment header"):
+            self.parse(
+                b"--boundary\r\nContent-Disposition: mixed\r\n\r\ndata\r\n--boundary--"
+            )
+        self.reset()
+        with self.assertMPE("Invalid Content-Disposition segment header"):
+            self.parse(
+                b"--boundary\r\nContent-Disposition: form-data\r\n\r\ndata\r\n--boundary--"
+            )
+
+    def test_segment_count_limit(self):
+        self.reset(max_segment_count=1)
+        self.parse(b"--boundary\r\n")
+        self.parse(b"Content-Disposition: form-data; name=foo\r\n")
+        self.parse(b"\r\n")
+        with self.assertMPE("Maximum segment count exceeded"):
+            self.parse(b"\r\n--boundary\r\n")
+
+    def test_segment_size_limit(self):
+        self.reset(max_segment_size=5)
+        self.parse(b"--boundary\r\n")
+        self.parse(b"Content-Disposition: form-data; name=foo\r\n")
+        self.parse(b"\r\n")
+        with self.assertMPE("Maximum segment size exceeded"):
+            self.parse(b"123456")
+            self.parse(b"\r\n--boundary\r\n")
+
+    def test_partial_parts(self):
+        self.reset()
+        self.assertEqual([], self.parse(b"--boundary\r\n"))
+        self.assertEqual(
+            [], self.parse(b'Content-Disposition: form-data; name="foo"\r\n')
+        )
+        part = self.parse(b"\r\n")[0]
+        self.assertEqual(
+            [("Content-Disposition", 'form-data; name="foo"')], part.headerlist
+        )
+        # Write enough body data to trigger a new part
+        part = self.parse(b"body" * 10)[0]
+        # Write partial boundary, should stay incomplete
+        part = self.parse(b"more\r\n--boundary")[0]
+        # Turn the incomplete boundary into a terminator
+        parts = self.parse(b"--")
+        self.assertIsNone(parts[-1])
+
+    def test_segment_clen(self):
+        self.parse(b"--boundary\r\n")
+        self.parse(b"Content-Disposition: form-data; name=foo\r\n")
+        self.parse(b"Content-Length: 10\r\n")
+        self.parse(b"\r\n")
+        self.parse(b"x" * 10)
+        self.parse(b"\r\n--boundary--")
+
+    def test_segment_clen_exceeded(self):
+        self.parse(b"--boundary\r\n")
+        self.parse(b"Content-Disposition: form-data; name=foo\r\n")
+        self.parse(b"Content-Length: 10\r\n")
+        self.parse(b"\r\n")
+        with self.assertMPE("Segment Content-Length exceeded"):
+            self.parse(b"x" * 11)
+            self.parse(b"\r\n--boundary--")
+
+    def test_segment_clen_not_reached(self):
+        self.parse(b"--boundary\r\n")
+        self.parse(b"Content-Disposition: form-data; name=foo\r\n")
+        self.parse(b"Content-Length: 10\r\n")
+        self.parse(b"\r\n")
+        with self.assertMPE("Segment size does not match Content-Length header"):
+            self.parse(b"x" * 9)
+            self.parse(b"\r\n--boundary--")
+
+    def test_segment_handle_access(self):
+        self.parse(b"--boundary\r\n")
+        self.parse(b"Content-Disposition: form-data; name=foo; filename=bar.txt\r\n")
+        self.parse(b"Content-Type: text/x-foo; charset=ascii\r\n")
+        part = self.parse(b"\r\n")[0]
+        self.assertEqual(
+            part.header("Content-Disposition"), "form-data; name=foo; filename=bar.txt"
+        )
+        self.assertEqual(
+            part.header("CONTENT-Disposition"), "form-data; name=foo; filename=bar.txt"
+        )
+        self.assertEqual(
+            part["Content-Disposition"], "form-data; name=foo; filename=bar.txt"
+        )
+        self.assertEqual(
+            part["CONTENT-Disposition"], "form-data; name=foo; filename=bar.txt"
+        )
+        self.assertEqual(part.name, "foo")
+        self.assertEqual(part.filename, "bar.txt")
+        with self.assertRaises(KeyError):
+            part["Missing"]


### PR DESCRIPTION
This PR introduces a new `PushMultipartParser` that avoids any form of (blocking) IO, which allows it to be used in async contexts. It is also significantly faster (x2 - x10) and less susceptible for certain worst-case inputs.

The old (blocking) `MultipartParser` API now uses this new `PushMultipartParser` internally and benefits from all improvements.

See https://sans-io.readthedocs.io/ on why this type of parser is preferable and please test and benchmark this new implementation if you have the time.

Still missing:
* [x] Documentation.
* [x] A couple percent of code coverage.
* [x] Some minor cleanup