### PR TITLE
fix: Decode field names and filenames correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,25 +15,25 @@ Release 1.2
 This release improves error handling, fixes several parser edge-cases and adds
 new functionality. API changes are backwards compatible.
 
-* feat: New `is_form_request(environ)` helper.
-* feat: Split up `MultipartError`` into more specific exceptions and added HTTP
-  status code info to each one. All exceptions are subclasses of `MultipartError`.
-* feat: Added `parse_form_data(ignore_errors)` parameter to throw exceptions in
+* feat: Split up `MultipartError`` into more specific exceptions and add HTTP
+  status code hints. All exceptions are subclasses of `MultipartError`.
+* feat: New `parse_form_data(ignore_errors)` parameter to throw exceptions in
   non-strict mode, or suppress exceptions in strict mode. Default behavior does
-  not change.
-* feat: Added specialized `content_disposition_[un]quote` functions.
-* feat: `parse_options_header` can now use different unquote functions. The
+  not change (throw in strict-mode, ignore in non-strict mode).
+* feat: New `is_form_request(environ)` helper.
+* feat: New specialized `content_disposition_[un]quote` functions.
+* feat: `parse_options_header()` can now use different unquote functions. The
   default does not change.
-* fix: `parse_form_data` no longer checks the request method and `is_form_request`
-  also ignores it. All methods can carry parse-able form data, including unknown
-  methods. The only reliable way is to check the `Content-Type` header, which
-  both functions do.
+* fix: `parse_form_data()` no longer checks the request method and the new
+  `is_form_request` function also ignores it. All methods can carry parse-able
+  form data, including unknown methods. The only reliable way is to check the
+  `Content-Type` header, which both functions do.
 * fix: First boundary not detected if separated by chunk border.
 * fix: Allow CRLF in front of first boundary, even in strict mode.
 * fix: Fail fast if first boundary is broken or part of the preamble.
 * fix: Fail if stream ends without finding any boundary at all.
 * fix: Use modern WHATWG quoting rules for field names and filenames (#60).
-  Legacy quoting still supported as a fallback.
+  Legacy quoting is still supported as a fallback.
 
 Release 1.1
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ new functionality. API changes are backwards compatible.
 * feat: Added `parse_form_data(ignore_errors)` parameter to throw exceptions in
   non-strict mode, or suppress exceptions in strict mode. Default behavior does
   not change.
+* feat: Added specialized `content_disposition_[un]quote` functions.
+* feat: `parse_options_header` can now use different unquote functions. The
+  default does not change.
 * fix: `parse_form_data` no longer checks the request method and `is_form_request`
   also ignores it. All methods can carry parse-able form data, including unknown
   methods. The only reliable way is to check the `Content-Type` header, which
@@ -29,6 +32,8 @@ new functionality. API changes are backwards compatible.
 * fix: Allow CRLF in front of first boundary, even in strict mode.
 * fix: Fail fast if first boundary is broken or part of the preamble.
 * fix: Fail if stream ends without finding any boundary at all.
+* fix: Use modern WHATWG quoting rules for field names and filenames (#60).
+  Legacy quoting still supported as a fallback.
 
 Release 1.1
 ===========

--- a/test/test_header_utils.py
+++ b/test/test_header_utils.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+import functools
 import unittest
 import multipart
+
 
 class TestHeaderParser(unittest.TestCase):
 
@@ -11,10 +13,22 @@ class TestHeaderParser(unittest.TestCase):
         self.assertEqual('ie.exe', unquote('"\\\\network\\ie.exe"', True))
         self.assertEqual('ie.exe', unquote('"c:\\wondows\\ie.exe"', True))
 
+        unquote = multipart.content_disposition_unquote
+        self.assertEqual('foo', unquote('"foo"'))
+        self.assertEqual('foo"bar', unquote('foo%22bar'))
+        self.assertEqual('foo"bar', unquote('"foo%22bar"'))
+        self.assertEqual('foo"bar', unquote('"foo\\"bar"'))
+        self.assertEqual('ie.exe', unquote('"\\\\network\\ie.exe"', True))
+        self.assertEqual('ie.exe', unquote('"c:\\wondows\\ie.exe"', True))
+
     def test_token_quote(self):
         quote = multipart.header_quote
         self.assertEqual(quote('foo'), 'foo')
         self.assertEqual(quote('foo"bar'), '"foo\\"bar"')
+
+        quote = multipart.content_disposition_quote
+        self.assertEqual(quote('foo'), '"foo"')
+        self.assertEqual(quote('foo"bar'), '"foo%22bar"')
 
     def test_options_parser(self):
         parse = multipart.parse_options_header
@@ -22,6 +36,11 @@ class TestHeaderParser(unittest.TestCase):
         self.assertEqual(parse(head+'filename="Test.txt"')[0], 'form-data')
         self.assertEqual(parse(head+'filename="Test.txt"')[1]['name'], 'Test')
         self.assertEqual(parse(head+'filename="Test.txt"')[1]['filename'], 'Test.txt')
-        self.assertEqual(parse(head+'FileName="Te\\"st.txt"')[1]['filename'], 'Te"st.txt')
+        self.assertEqual(parse(head+'FileName="Te\\"s\\\\t.txt"')[1]['filename'], 'Te"s\\t.txt')
         self.assertEqual(parse(head+'filename="C:\\test\\bla.txt"')[1]['filename'], 'bla.txt')
         self.assertEqual(parse(head+'filename="\\\\test\\bla.txt"')[1]['filename'], 'bla.txt')
+        self.assertEqual(parse(head+'filename="täst.txt"')[1]['filename'], 'täst.txt')
+
+        parse = functools.partial(multipart.parse_options_header, unquote=multipart.content_disposition_unquote)
+        self.assertEqual(parse(head+'FileName="Te%22s\\\\t.txt"')[1]['filename'], 'Te"s\\\\t.txt')
+

--- a/test/utils.py
+++ b/test/utils.py
@@ -48,7 +48,7 @@ class BaseParserTest(unittest.TestCase):
         line = to_bytes(header) + b': ' + to_bytes(value)
         for opt, val in opts.items():
             if val is not None:
-                line += b"; " + to_bytes(opt) + b'=' + to_bytes(multipart.header_quote(val))
+                line += b"; " + to_bytes(opt) + b'=' + to_bytes(multipart.content_disposition_quote(val))
         self.write(line + b'\r\n')
 
     def write_field(self, name, data, filename=None, content_type=None):


### PR DESCRIPTION
See #60

Question 1: The new `content_disposition_[un]quote()` functions have a really long name. Any better ideas? I wanted to distinguish those from the old `header_[un]quote()` functions.

~Question 2: We don't use the old quoting functions anymore, but others do. Keep them?~
Answer: Yes we use the old functions for all other headers (e.g. content-type). Do not deprecate them.