### PR TITLE
Error handling overhaul

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,19 @@ and may break applications that rely on *incorrect* or *undefined* behavior.
 Release 1.2
 ===========
 
-Not released yet.
+This release improves error handling and adds new functionality. API changes are
+backwards compatible.
+
+* feat: New `is_form_request(environ)` helper.
+* feat: Split up `MultipartError`` into more specific exceptions and added HTTP
+  status code info to each one. All exceptions are subclasses of `MultipartError`.
+* feat: Added `parse_form_data(ignore_errors)` parameter to throw exceptions in
+  non-strict mode, or suppress exceptions in strict mode. Default behavior does
+  not change.
+* fix: `parse_form_data` no longer checks the request method and `is_form_request`
+  also ignores it. All methods can carry parse-able form data, including unknown
+  methods. The only reliable way is to check the `Content-Type` header, which
+  both functions do.
 
 Release 1.1
 ===========

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: venv
 
 .PHONY: coverage
 coverage: venv
-	$(VENV)/bin/pytest . -q --cov=multipart --cov-report=term --cov-report=html:build/htmlcov
+	$(VENV)/bin/pytest . -q --cov=multipart --cov-branch --cov-report=term --cov-report=html:build/htmlcov
 
 upload: build
 	$(VENV)/bin/python3 -m twine upload --skip-existing dist/multipart-*

--- a/multipart.py
+++ b/multipart.py
@@ -904,8 +904,8 @@ def parse_form_data(environ, charset="utf8", strict=False, **kwargs):
             for key, values in data.items():
                 for value in values:
                     forms.append(key, value)
-        else:
-            raise ParserError("Unsupported Content-Type")
+        elif strict:
+            raise ParserWarning("Unsupported Content-Type")
 
     except MultipartError:
         if strict:

--- a/multipart.py
+++ b/multipart.py
@@ -157,7 +157,7 @@ class _cached_property:
         self.func = func
 
     def __get__(self, obj, cls):
-        if obj is None: return self
+        if obj is None: return self  # pragma: no cover
         value = obj.__dict__[self.func.__name__] = self.func(obj)
         return value
 

--- a/multipart.py
+++ b/multipart.py
@@ -856,8 +856,6 @@ def parse_form_data(environ, charset="utf8", strict=False, **kwargs):
         raise ParserWarning("No 'wsgi.input' in environment.")
 
     try:
-        if environ.get("REQUEST_METHOD", "GET").upper() not in ("POST", "PUT"):
-            raise ParserError("Request method other than POST or PUT")
         try:
             content_length = int(environ.get("CONTENT_LENGTH", "-1"))
         except ValueError:

--- a/multipart.py
+++ b/multipart.py
@@ -12,7 +12,9 @@ License: MIT (see LICENSE file)
 __author__ = "Marcel Hellkamp"
 __version__ = '1.2.0-dev'
 __license__ = "MIT"
-__all__ = ["MultipartError", "parse_form_data", "MultipartParser", "MultipartPart", "PushMultipartParser", "MultipartSegment"]
+__all__ = ["MultipartError", "is_form_request", "parse_form_data",
+           "MultipartParser", "MultipartPart", "PushMultipartParser",
+           "MultipartSegment"]
 
 
 import re
@@ -786,6 +788,20 @@ class MultipartPart(object):
 ##############################################################################
 #################################### WSGI ####################################
 ##############################################################################
+
+
+def is_form_request(environ):
+    """ Return True if the environ represents a form request that can be parsed
+        with :func:`parse_form_data`. Checks for a compatible `Content-Type`
+        header.
+    """
+
+    content_type = environ.get("CONTENT_TYPE", "")
+    return content_type.split(";", 1)[0].strip().lower() in (
+        "multipart/form-data",
+        "application/x-www-form-urlencoded",
+        "application/x-url-encoded"
+    )
 
 
 def parse_form_data(environ, charset="utf8", strict=False, **kwargs):

--- a/test/test_legacy_parser.py
+++ b/test/test_legacy_parser.py
@@ -185,3 +185,14 @@ class TestMultipartParser(BaseParserTest):
 
         # Large content length (we don't care)
         list(self.parser(content_length=clen+1))
+
+    def test_segment_close_twice(self):
+        self.write_field("file1", 'x'*1024, filename="foo.bin")
+        self.write_end()
+
+        # Correct content length
+        file1 = self.parser().get("file1")
+        self.assertFalse(file1.file.closed)
+        file1.close()
+        self.assertFalse(file1.file)
+        file1.close() # Do nothing

--- a/test/test_push_parser.py
+++ b/test/test_push_parser.py
@@ -409,7 +409,7 @@ class TestPushParser(PushTestBase):
         first_error = self.parser.error
         self.assertIsInstance(first_error, multipart.ParserError)
         # The first error should stick
-        with self.assertRaises(multipart.ParserClosedError):
+        with self.assertRaises(multipart.ParserStateError):
             self.parse('more junk')
         self.assertIs(self.parser.error, first_error)
         with self.assertRaises(multipart.ParserError):

--- a/test/test_push_parser.py
+++ b/test/test_push_parser.py
@@ -398,6 +398,26 @@ class TestPushParser(PushTestBase):
             self.parse('--boundary\r\n',
                    'Content-Type: image/png\r\n', '\r\n', 'abc'*1024+'\r\n', '--boundary--')
 
+    def test_error_property(self):
+        with self.assertRaises(multipart.MultipartError):
+            self.parse('--boundary\r\njunk\r\n--boundary--')
+        self.assertIsInstance(self.parser.error, multipart.ParserError)
+
+    def test_error_twice(self):
+        with self.assertRaises(multipart.ParserError):
+            self.parse('--boundary\r\njunk\r\n--boundary--')
+        first_error = self.parser.error
+        self.assertIsInstance(first_error, multipart.ParserError)
+        # The first error should stick
+        with self.assertRaises(multipart.ParserClosedError):
+            self.parse('more junk')
+        self.assertIs(self.parser.error, first_error)
+        with self.assertRaises(multipart.ParserError):
+            self.parser.close()
+        self.assertIs(self.parser.error, first_error)
+
+
+
 
 
 


### PR DESCRIPTION
Error handling needs some work. This PR changes quite a bit:

* Split up `MultipartError` into semantically meaningful sub-exceptions.
* Introduce a `parse_form_data(..., ignore_errors)` parameter that can be used to throw exceptions even in non-strict mode, or to suppress exceptions in strict mode. The default behavior stays the same: Throw in strict mode and ignore in non-struct mode.
* Introduce `is_form_request(environ)` so you can check if a request is a form request before calling `parse_form_data` and trigger an exception.
* Do not restrict form requests to `POST` or `PUT`. The only aspect that reliably identifies form submissions is the content type header.

All API changes are backwards compatible. Some behavior changes are not, but they only change undocumented or wrong behavior.