### PR TITLE
Parser tweaks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ and may break applications that rely on *incorrect* or *undefined* behavior.
 Release 1.2
 ===========
 
-This release improves error handling and adds new functionality. API changes are
-backwards compatible.
+This release improves error handling, fixes several parser edge-cases and adds
+new functionality. API changes are backwards compatible.
 
 * feat: New `is_form_request(environ)` helper.
 * feat: Split up `MultipartError`` into more specific exceptions and added HTTP
@@ -25,6 +25,10 @@ backwards compatible.
   also ignores it. All methods can carry parse-able form data, including unknown
   methods. The only reliable way is to check the `Content-Type` header, which
   both functions do.
+* fix: First boundary not detected if separated by chunk border.
+* fix: Allow CRLF in front of first boundary, even in strict mode.
+* fix: Fail fast if first boundary is broken or part of the preamble.
+* fix: Fail if stream ends without finding any boundary at all.
 
 Release 1.1
 ===========

--- a/multipart.py
+++ b/multipart.py
@@ -396,10 +396,12 @@ class PushMultipartParser:
                         break  # wait for more data
 
                 elif self._state is _BODY:
+
+                    # Ensure there is enough data in buffer to fit a delimiter
                     if offset + d_len + 2 > bufferlen:
                         break  # wait for more data
 
-                    # Scan for CRLF + boundary + (CRLF or '--')
+                    # Scan for delimiter (CRLF + boundary + (CRLF or '--'))
                     index = buffer.find(delimiter, offset)
                     if index > -1: 
                         next_start = index + d_len + 2
@@ -422,13 +424,13 @@ class PushMultipartParser:
                                 self._state = _HEADER
                                 continue
 
-                    # The buffer may contain a partial delimiter at the end, so
-                    # we have to keep the last part.
+                    # Keep enough in buffer to accout for a partial delimiter at
+                    # the end, but emiot the rest.
                     chunk_end = bufferlen - (d_len + 1)
-                    if chunk_end > offset:
-                        self._current._update_size(chunk_end - offset)
-                        yield buffer[offset:chunk_end]
-                        offset = chunk_end
+                    assert chunk_end > offset  # Always true
+                    self._current._update_size(chunk_end - offset)
+                    yield buffer[offset:chunk_end]
+                    offset = chunk_end
                     break  # wait for more data
 
                 else:  # pragma: no cover


### PR DESCRIPTION
Multiple parser improvements

fix: Allow CRLF in front of first boundary even in strict mode

  Browsers do not do this, but some HTTP client libaries do and it's
  technically allowed.

fix: Fail on invalid first boundary instead of skipping the first segment

  As per spec, the start boundary must be at position zero, or start with CRLF
  to separate it from the preamble. Boundaries are forbidden in segment
  bodies, but not in the preamble. This means that a preamble can actually
  contain the boundary, as long as it does not start with CRLF. This is
  nonsense, so let's ignore the spec here. A preamble that contains the
  boundary is so rare and suspicious that we assume a broken or malicious
  client and fail fast, even in non-strict mode. This is way better than
  silently skipping the first segment and loosing data.

fix: Accept tiny (1 byte) chunks and arbitrary chunk borders

  There were edge cases where a very uncommon chunk border would break the
  parser. This is fixed and properly tested now.

fix: Fail if message did not contain the boundary at all.

  In strict mode, we fail very fast (because the message is either empty, or
  the message does not start with a boundary. In non-strict mode, we fail
  at the end when the parser closes in PREAMBLE state.
