### PR TITLE
WIP: Allow subclassing MultipartSegment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Release 1.3
 **Not released yet**
 
 * feat: Nicer error messages when reading from a closed ``MultipartPart``.
+* feat: Support custom `MultipartSegment` subclasses to be used and emitted by
+  `PushMultipartParser`. However, the API between parser and segment is not
+  stable yet. Overriding any of the ``_on_*`` methods may break during releases.
 
 Release 1.2
 ===========


### PR DESCRIPTION
Allow use of the core parsing functionality for other use cases (e.g. `multipart/byterange` as described in #73) by allowing users to subclass `MultipartSegment`.

This is a WIP. First step was to clean up the API between `PushMultipartParser` and `MultipartSegment` to make it easier to hook into those APIs. The new `MultipartSegment._on_*` methods are still private APIs and may change between releases, so be careful. But it looks nice now, so future changes should be less likely.

One idea was to split the segment class into `MultipartSegmentBase` implementing universal parsing logic only, and `MultipartSegment` implementing the additional checks and logic for form-data segments. I tried that, but it reduced throughput by up to 5% in some tests and made documentation more complicated. I'm not sure if I really want that, but it's not from the table just yet.