### PR TITLE
docs: show supported python versions in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ Python multipart/form-data parser
     :target: https://pypi.python.org/pypi/multipart/
     :alt: Latest Version
 
+.. image:: https://img.shields.io/pypi/pyversions/multipart.svg?color=%2334D058
+    :target: https://pypi.python.org/pypi/multipart/
+    :alt: Supported Python Version
+
 .. image:: https://img.shields.io/pypi/l/multipart.svg
     :target: https://pypi.python.org/pypi/multipart/
     :alt: License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: CGI Tools/Libraries",
     "Topic :: Internet :: WWW/HTTP :: WSGI",
     "Programming Language :: Python :: 3",
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 
 [project.urls]


### PR DESCRIPTION
badge result:
<img width="269" alt="image" src="https://github.com/user-attachments/assets/2903bc62-81bf-4db5-b010-fc5f5eb96da6" />
