### PR TITLE
Refactor parser logic to better allow subclassing

### DIFF
--- a/multipart.py
+++ b/multipart.py
@@ -287,6 +287,8 @@ def parse_options_header(header, options=None, unquote=header_unquote):
 ##############################################################################
 
 
+# Constants used by the parser
+_HEADER_EXPECTED = frozenset(["Content-Disposition", "Content-Type", "Content-Length"])
 # Parser states as constants
 _PREAMBLE = "PREAMBLE"
 _HEADER = "HEADER"
@@ -555,8 +557,9 @@ class PushMultipartParser:
             name = name.strip().title()
             if not col or not name:
                 raise ParserError("Malformed segment header")
-            if " " in name or not name.isascii() or not name.isprintable():
-                raise ParserError("Invalid segment header name")
+            if name not in _HEADER_EXPECTED:
+                if " " in name or not name.isascii() or not name.isprintable():
+                    raise ParserError("Invalid segment header name")
             value = value.strip()
         except UnicodeDecodeError as err:
             raise ParserError("Segment header failed to decode", err)


### PR DESCRIPTION
This tries to fix #73 by moving all general purpose parser logic out of `MultipartSegment` back into the parser where it belongs and isolating `form-data` specific checks into a private parser method which can be overridden. Developers can now subclass `PushMultipartParser` and override `_create_segment(self, headerlist)` to support other multipart stream types (e.g. `multipart/byterange` or `multipart/mixed`) if necessary.

The change has a minimal impact on performance and actually performs better for the relevant use cases (large forms or large uploads). 

